### PR TITLE
Add visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # update_opencore
+![Banner](images/banner.svg)
 www.youtube.com/@HackintoshAndBeyond
 
 Video da ferramenta: https://youtu.be/dH-TH812sTQ
@@ -11,6 +12,7 @@ Este script foi desenvolvido para automatizar o processo de atualização do Ope
 Funcionalidades:
 
 Interface de Menu Intuitiva: Um menu simples e direto ao ponto permite que o usuário escolha a operação desejada com facilidade.
+![Menu](images/menu.svg)
 Detecção Automática da Partição EFI: O script localiza e identifica automaticamente as partições EFI montadas no sistema.
 Backup Automático da EFI: Antes de fazer qualquer modificação, o script cria um backup completo da pasta EFI em EFI-Backup-<data>-<hora> na própria partição EFI, permitindo reverter facilmente para uma configuração anterior em caso de problemas.
 Download do OpenCore: Baixa a última versão RELEASE ou DEBUG do OpenCore diretamente do repositório oficial da Acidanthera no GitHub.

--- a/images/banner.svg
+++ b/images/banner.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="150" viewBox="0 0 600 150">
+  <rect width="600" height="150" fill="#2b2b2b"/>
+  <text x="300" y="90" font-family="Arial, Helvetica, sans-serif" font-size="48" fill="#ffffff" text-anchor="middle">Update-OC-EFI Script</text>
+</svg>

--- a/images/menu.svg
+++ b/images/menu.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="200" viewBox="0 0 400 200" font-family="Arial, Helvetica, sans-serif">
+  <rect width="400" height="200" fill="#f5f5f5"/>
+  <text x="20" y="40" font-size="18" fill="#333">1. Atualizar OpenCore (RELEASE)</text>
+  <text x="20" y="70" font-size="18" fill="#333">2. Atualizar OpenCore (DEBUG)</text>
+  <text x="20" y="100" font-size="18" fill="#333">3. Atualizar apenas drivers</text>
+  <text x="20" y="130" font-size="18" fill="#333">4. Adicionar novas chaves</text>
+  <text x="20" y="160" font-size="18" fill="#333">5. Validar config.plist</text>
+  <text x="20" y="190" font-size="18" fill="#333">6. Atualizar arquivos BOOT</text>
+</svg>


### PR DESCRIPTION
## Summary
- include banner and menu images
- embed new visuals in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ce1ca018483289428a968eb7aedc2

## Summary by Sourcery

Documentation:
- Embed banner and menu SVG visuals in the README and add corresponding image assets.